### PR TITLE
Release 2.0.0 - Breaking changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -574,6 +574,11 @@ module.exports = function(app) {
                 value_template: value_template || "{{ value_json.value }}"
             };
 
+            // Ensure device_class is null if it's an empty string
+            if (configPayload.device_class === "") {
+                configPayload.device_class = null;
+            }
+
             app.debug("Registering HA entity for path: ", configPayload);
 
             // Publish the discovery message to the correct topic
@@ -599,7 +604,8 @@ module.exports = function(app) {
          * Determines the device class for a given Signal K path
          * @param {string} path - The SignalK path
          * @param {Object} metadata - The metadata object for the path
-         * @returns {string} The device class
+         * @returns {string} The device class - must be one of the following:
+         * 'date', 'enum', 'timestamp', 'apparent_power', 'aqi', 'area', 'atmospheric_pressure', 'battery', 'blood_glucose_concentration', 'carbon_monoxide', 'carbon_dioxide', 'conductivity', 'current', 'data_rate', 'data_size', 'distance', 'duration', 'energy', 'energy_storage', 'frequency', 'gas', 'humidity', 'illuminance', 'irradiance', 'moisture', 'monetary', 'nitrogen_dioxide', 'nitrogen_monoxide', 'nitrous_oxide', 'ozone', 'ph', 'pm1', 'pm10', 'pm25', 'power_factor', 'power', 'precipitation', 'precipitation_intensity', 'pressure', 'reactive_power', 'signal_strength', 'sound_pressure', 'speed', 'sulphur_dioxide', 'temperature', 'volatile_organic_compounds', 'volatile_organic_compounds_parts', 'voltage', 'volume', 'volume_storage', 'volume_flow_rate', 'water', 'weight', 'wind_speed'
          */
         function determineDeviceClass(path, metadata) {
             if (!metadata) {

--- a/index.js
+++ b/index.js
@@ -560,9 +560,9 @@ module.exports = function(app) {
             const configPayload = {
                 device: {
                     identifiers: ["41c0ad04-4bcd-425a-b749-8bf4554d4cf4"],
-                    manufacturer: "signalk-mqtt-sensors",
-                    model: "signalk-mqtt-sensors",
-                    name: "Signal K MQTT Sensors",
+                    manufacturer: "signalk-sensors",
+                    model: "signalk-sensors",
+                    name: "SignalK Sensors",
                     sw_version: version
                 },
                 name: displayName,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signalk-mqtt-sensors",
-  "version": "1.2.2",
-  "description": "Signal K Node Server Plugin that transfers data to/from MQTT and Signal K.",
+  "version": "2.0.0",
+  "description": "SignalK Node Server Plugin that transfers data to/from MQTT and SignalK.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Minor update - but a breaking change, since the entity_ids of created entities will be different in this version for home assistant. If you aren't using the Export to Hass feature, you won't be impacted. Otherwise you will need to update automations to use the new entity id's - which are shorter than in the past.